### PR TITLE
Add additional metadata to index.

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
   "support_url": "https://github.com/mattermost/mattermost-plugin-legal-hold/issues",
   "release_notes_url": "https://github.com/mattermost/mattermost-plugin-legal-hold/releases/tag/v0.1.0",
   "icon_path": "assets/starter-template-icon.svg",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "min_server_version": "6.2.1",
   "server": {
     "executables": {

--- a/server/model/channel.go
+++ b/server/model/channel.go
@@ -1,0 +1,11 @@
+package model
+
+type ChannelMetadata struct {
+	ChannelID          string
+	ChannelName        string
+	ChannelDisplayName string
+	ChannelType        string
+	TeamID             string
+	TeamName           string
+	TeamDisplayName    string
+}

--- a/server/model/export.go
+++ b/server/model/export.go
@@ -25,6 +25,7 @@ func NewLegalHoldCursor(startTime int64) LegalHoldCursor {
 type LegalHoldPost struct {
 
 	// From Team
+	TeamID          string `csv:"TeamId"`
 	TeamName        string `csv:"TeamName"`
 	TeamDisplayName string `csv:"TeamDisplayName"`
 

--- a/server/model/index_test.go
+++ b/server/model/index_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestMerge(t *testing.T) {
-	oldIndex := LegalHoldIndex{
+	oldIndex := LegalHoldIndexUsers{
 		"user1": {
 			Username: "oldUser",
 			Email:    "oldUser@example.com",
@@ -27,7 +27,7 @@ func TestMerge(t *testing.T) {
 		},
 	}
 
-	newIndex := LegalHoldIndex{
+	newIndex := LegalHoldIndexUsers{
 		"user1": {
 			Username: "newUser",
 			Email:    "newUser@example.com",
@@ -46,7 +46,7 @@ func TestMerge(t *testing.T) {
 		},
 	}
 
-	expectedIndexAfterMerge := LegalHoldIndex{
+	expectedIndexAfterMerge := LegalHoldIndexUsers{
 		"user1": {
 			Username: "newUser",
 			Email:    "newUser@example.com",


### PR DESCRIPTION
This includes:
* Team name, id, display name
* Channel name, id, display name and type
* Basic LegalHold details (name, id, display name, start time, last executed at time)

Also adds TeamID to CSV files of messages.

This is to make the HTML processed version more human-friendly.

Fixes #22