### PR TITLE
Fix process.env frontend issue

### DIFF
--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -2,12 +2,18 @@ const exec = require('child_process').exec;
 
 const path = require('path');
 
+const webpack = require('webpack');
+
 const PLUGIN_ID = require('../plugin.json').id;
 
 const NPM_TARGET = process.env.npm_lifecycle_event; //eslint-disable-line no-process-env
 const isDev = NPM_TARGET === 'debug' || NPM_TARGET === 'debug:watch';
 
-const plugins = [];
+const plugins = [
+    new webpack.ProvidePlugin({
+        process: 'process/browser',
+    }),
+];
 if (NPM_TARGET === 'build:watch' || NPM_TARGET === 'debug:watch') {
     plugins.push({
         apply: (compiler) => {


### PR DESCRIPTION
#### Summary

When the plugin's webapp bundle is loaded in the frontend, we hit this error that makes the plugin fail to load. Some libraries expect `process.env.NODE_ENV` to be available during runtime. By default, attempting to access this property results in a null pointer because `process` is not normally defined in the context of the browser.

This PR configures a webpack plugin that fills in the `process.env.NODE_ENV` variable in the bundle, to match the value at compilation time. See more here https://stackoverflow.com/a/64553486