### PR TITLE
docs: note on timeout issues for large downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Although a valid Mattermost Enterprise Edition License is required if using this
 
 If you're running an Enterprise Edition of Mattermost and don't already have a valid license, you can obtain a trial license from **System Console > Edition and License**. If you're running the Team Edition of Mattermost, including when you run the server directly from source, you may instead configure your server to enable both testing (`ServiceSettings.EnableTesting`) and developer mode (`ServiceSettings.EnableDeveloper`). These settings are not recommended in production environments.
 
-
 ## How To Install
 
 Download the latest released version and upload to your Mattermost installation on the plugins page
@@ -23,8 +22,8 @@ of the System Console in the usual way.
 Once the plugin is installed, a new "Legal Hold" section will appear in the System Console UI
 in the Plugins section. There are two main settings:
 
-* **Enable Plugin**: controls whether the plugin is enabled. It must be enabled to use it.
-* **Time of Day**: this setting controls at what time the delay collection of Legal Hold data
+- **Enable Plugin**: controls whether the plugin is enabled. It must be enabled to use it.
+- **Time of Day**: this setting controls at what time the delay collection of Legal Hold data
   should occur. We recommend choosing a quiet time of day to minimise impact on your users. Make
   sure to specify the time in the format shown in the example.
 
@@ -40,8 +39,8 @@ present in your Mattermost server on the first run of the job will be saved (i.e
 already been purged by a data retention policy at the time of the first run will not be included
 in the legal hold). Once data is held by the Legal Hold, it will not be affected by Data Retention
 policy. However, newly created Legal Holds will not be able to access data that was already purged
-by Data Retention policy at the time of their first run *even if the data is held in an existing
-legal hold*.
+by Data Retention policy at the time of their first run _even if the data is held in an existing
+legal hold_.
 
 You can edit the name, end data and users in a Legal Hold. Adding new users to a legal hold will only
 include their data from the next run of the hold. Similarly, removing a user from the hold will
@@ -58,3 +57,9 @@ permanently purged from the storage area, and cannot be recovered.
 
 See the `processor` subdirectory for how to turn the downloaded zip file into a human readable HTML
 export that you can view and search in a web browser.
+
+## A note on downlading large legal holds
+
+For large legal holds, the download process can take more time than the HTTP request timeout. If you are experiencing timeouts, you can increase the timeout under **System Console** > **Web server** > **Write timeout** or in your `config.json` file. This is a global setting for the entire server.
+
+Keep in mind that the same applies for reverse proxies, which may have their own timeout settings. If you are using a reverse proxy, you may need to adjust the timeout settings there as well.


### PR DESCRIPTION
Adds a section in the README specifying potential issues with large legal holds and low timeout settings.

Closes #44 