### PR TITLE
fix: clean up temporary directory on exit of export processor

### DIFF
--- a/processor/cmd/root.go
+++ b/processor/cmd/root.go
@@ -54,6 +54,11 @@ func Process(_ *cobra.Command, _ []string) {
 		fmt.Printf("Error while creating temporary directory: %v\n", err)
 	}
 
+	// Clean up the temporary directory when we're done.
+	defer func() {
+		os.RemoveAll(tempPath)
+	}()
+
 	if err := ExtractZip(legalHoldData, tempPath); err != nil {
 		fmt.Printf("Error while extracting: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
#### Summary

Cleans up the `tempPath` after the `Process` call is done.

Fixes #25