### PR TITLE
fix: end date not required when updating legal hold

### DIFF
--- a/webapp/src/components/update_legal_hold_form/update_legal_hold_form.tsx
+++ b/webapp/src/components/update_legal_hold_form/update_legal_hold_form.tsx
@@ -188,7 +188,7 @@ const UpdateLegalHoldForm = (props: UpdateLegalHoldFormProps) => {
                             type='date'
                             autoComplete='off'
                             autoFocus={false}
-                            required={true}
+                            required={false}
                             name={'Ending at'}
                             label={'Ending at'}
                             placeholder={'Ending at'}


### PR DESCRIPTION
#### Summary
Make the end date field not required to avoid validation errors when the form can be successfully submitted.

Closes #56 