### PR TITLE
feat: allow excluding public channels from a legal hold

### DIFF
--- a/server/legalhold/legal_hold.go
+++ b/server/legalhold/legal_hold.go
@@ -87,7 +87,7 @@ func (ex *Execution) GetChannels() error {
 			return appErr
 		}
 
-		channelIDs, err := ex.store.GetChannelIDsForUserDuring(userID, ex.ExecutionStartTime, ex.ExecutionEndTime)
+		channelIDs, err := ex.store.GetChannelIDsForUserDuring(userID, ex.ExecutionStartTime, ex.ExecutionEndTime, ex.LegalHold.ExcludePublicChannels)
 		if err != nil {
 			return err
 		}

--- a/server/model/legal_hold.go
+++ b/server/model/legal_hold.go
@@ -159,10 +159,11 @@ func NewLegalHoldFromCreate(lhc CreateLegalHold) LegalHold {
 
 // UpdateLegalHold holds the data that is specified in the API call to update a LegalHold.
 type UpdateLegalHold struct {
-	ID          string   `json:"id"`
-	DisplayName string   `json:"display_name"`
-	UserIDs     []string `json:"user_ids"`
-	EndsAt      int64    `json:"ends_at"`
+	ID                    string   `json:"id"`
+	DisplayName           string   `json:"display_name"`
+	UserIDs               []string `json:"user_ids"`
+	ExcludePublicChannels bool     `json:"exclude_public_channels"`
+	EndsAt                int64    `json:"ends_at"`
 }
 
 func (ulh UpdateLegalHold) IsValid() error {
@@ -195,4 +196,5 @@ func (lh *LegalHold) ApplyUpdates(updates UpdateLegalHold) {
 	lh.DisplayName = updates.DisplayName
 	lh.UserIDs = updates.UserIDs
 	lh.EndsAt = updates.EndsAt
+	lh.ExcludePublicChannels = updates.ExcludePublicChannels
 }

--- a/server/model/legal_hold.go
+++ b/server/model/legal_hold.go
@@ -11,17 +11,18 @@ import (
 
 // LegalHold represents one legal hold.
 type LegalHold struct {
-	ID                   string   `json:"id"`
-	Name                 string   `json:"name"`
-	DisplayName          string   `json:"display_name"`
-	CreateAt             int64    `json:"create_at"`
-	UpdateAt             int64    `json:"update_at"`
-	UserIDs              []string `json:"user_ids"`
-	StartsAt             int64    `json:"starts_at"`
-	EndsAt               int64    `json:"ends_at"`
-	LastExecutionEndedAt int64    `json:"last_execution_ended_at"`
-	ExecutionLength      int64    `json:"execution_length"`
-	Secret               string   `json:"secret"`
+	ID                    string   `json:"id"`
+	Name                  string   `json:"name"`
+	DisplayName           string   `json:"display_name"`
+	CreateAt              int64    `json:"create_at"`
+	UpdateAt              int64    `json:"update_at"`
+	UserIDs               []string `json:"user_ids"`
+	StartsAt              int64    `json:"starts_at"`
+	EndsAt                int64    `json:"ends_at"`
+	ExcludePublicChannels bool     `json:"exclude_public_channels"`
+	LastExecutionEndedAt  int64    `json:"last_execution_ended_at"`
+	ExecutionLength       int64    `json:"execution_length"`
+	Secret                string   `json:"secret"`
 }
 
 // DeepCopy creates a deep copy of the LegalHold.
@@ -31,16 +32,17 @@ func (lh *LegalHold) DeepCopy() LegalHold {
 	}
 
 	newLegalHold := LegalHold{
-		ID:                   lh.ID,
-		Name:                 lh.Name,
-		DisplayName:          lh.DisplayName,
-		CreateAt:             lh.CreateAt,
-		UpdateAt:             lh.UpdateAt,
-		StartsAt:             lh.StartsAt,
-		EndsAt:               lh.EndsAt,
-		LastExecutionEndedAt: lh.LastExecutionEndedAt,
-		ExecutionLength:      lh.ExecutionLength,
-		Secret:               lh.Secret,
+		ID:                    lh.ID,
+		Name:                  lh.Name,
+		DisplayName:           lh.DisplayName,
+		CreateAt:              lh.CreateAt,
+		UpdateAt:              lh.UpdateAt,
+		StartsAt:              lh.StartsAt,
+		EndsAt:                lh.EndsAt,
+		ExcludePublicChannels: lh.ExcludePublicChannels,
+		LastExecutionEndedAt:  lh.LastExecutionEndedAt,
+		ExecutionLength:       lh.ExecutionLength,
+		Secret:                lh.Secret,
 	}
 
 	if len(lh.UserIDs) > 0 {
@@ -131,25 +133,27 @@ func (lh *LegalHold) BasePath() string {
 
 // CreateLegalHold holds the data that is specified in the API call to create a LegalHold.
 type CreateLegalHold struct {
-	Name        string   `json:"name"`
-	DisplayName string   `json:"display_name"`
-	UserIDs     []string `json:"user_ids"`
-	StartsAt    int64    `json:"starts_at"`
-	EndsAt      int64    `json:"ends_at"`
+	Name                  string   `json:"name"`
+	DisplayName           string   `json:"display_name"`
+	UserIDs               []string `json:"user_ids"`
+	StartsAt              int64    `json:"starts_at"`
+	EndsAt                int64    `json:"ends_at"`
+	ExcludePublicChannels bool     `json:"exclude_public_channels"`
 }
 
 // NewLegalHoldFromCreate creates and populates a new LegalHold instance from
 // the provided CreateLegalHold instance.
 func NewLegalHoldFromCreate(lhc CreateLegalHold) LegalHold {
 	return LegalHold{
-		ID:                   mattermostModel.NewId(),
-		Name:                 lhc.Name,
-		DisplayName:          lhc.DisplayName,
-		UserIDs:              lhc.UserIDs,
-		StartsAt:             lhc.StartsAt,
-		EndsAt:               lhc.EndsAt,
-		LastExecutionEndedAt: 0,
-		ExecutionLength:      86400000,
+		ID:                    mattermostModel.NewId(),
+		Name:                  lhc.Name,
+		DisplayName:           lhc.DisplayName,
+		UserIDs:               lhc.UserIDs,
+		StartsAt:              lhc.StartsAt,
+		EndsAt:                lhc.EndsAt,
+		ExcludePublicChannels: lhc.ExcludePublicChannels,
+		LastExecutionEndedAt:  0,
+		ExecutionLength:       86400000,
 	}
 }
 

--- a/server/store/sqlstore/legal_hold.go
+++ b/server/store/sqlstore/legal_hold.go
@@ -113,9 +113,7 @@ func (ss SQLStore) GetPostsBatch(channelID string, endTime int64, cursor model.L
 func (ss SQLStore) GetChannelIDsForUserDuring(userID string, startTime int64, endTime int64, excludePublic bool) ([]string, error) {
 	query := ss.replicaBuilder.
 		Select("distinct(cmh.channelid)").
-		From("channelmemberhistory as cmh")
-
-	query = query.
+		From("channelmemberhistory as cmh").
 		Where(sq.Lt{"cmh.jointime": endTime}).
 		Where(sq.Or{sq.Eq{"cmh.leavetime": nil}, sq.GtOrEq{"cmh.leavetime": startTime}}).
 		Where(sq.Eq{"cmh.userid": userID})
@@ -125,8 +123,6 @@ func (ss SQLStore) GetChannelIDsForUserDuring(userID string, startTime int64, en
 		query = query.Join("channels on cmh.channelid = channels.id").
 			Where(sq.NotEq{"channels.type": mattermostModel.ChannelTypeOpen})
 	}
-
-	ss.logger.Error(query.ToSql())
 
 	rows, err := query.Query()
 	if err != nil {

--- a/server/store/sqlstore/legal_hold.go
+++ b/server/store/sqlstore/legal_hold.go
@@ -110,13 +110,23 @@ func (ss SQLStore) GetPostsBatch(channelID string, endTime int64, cursor model.L
 // GetChannelIDsForUserDuring gets the channel IDs for all channels that the user indicated by userID is
 // a member of during the time period from (and including) the startTime up until (but not including) the
 // endTime.
-func (ss SQLStore) GetChannelIDsForUserDuring(userID string, startTime int64, endTime int64) ([]string, error) {
+func (ss SQLStore) GetChannelIDsForUserDuring(userID string, startTime int64, endTime int64, excludePublic bool) ([]string, error) {
 	query := ss.replicaBuilder.
 		Select("distinct(cmh.channelid)").
-		From("channelmemberhistory as cmh").
+		From("channelmemberhistory as cmh")
+
+	query = query.
 		Where(sq.Lt{"cmh.jointime": endTime}).
 		Where(sq.Or{sq.Eq{"cmh.leavetime": nil}, sq.GtOrEq{"cmh.leavetime": startTime}}).
 		Where(sq.Eq{"cmh.userid": userID})
+
+	// Exclude all public channels from the results
+	if excludePublic {
+		query = query.Join("channels on cmh.channelid = channels.id").
+			Where(sq.NotEq{"channels.type": mattermostModel.ChannelTypeOpen})
+	}
+
+	ss.logger.Error(query.ToSql())
 
 	rows, err := query.Query()
 	if err != nil {

--- a/server/store/sqlstore/legal_hold_test.go
+++ b/server/store/sqlstore/legal_hold_test.go
@@ -157,14 +157,20 @@ func TestLegalHold_GetChannelIDsForUserDuring_ExcludePublic(t *testing.T) {
 	require.NoError(t, err)
 	privateChannel, err := th.CreateChannel("private-channel", th.User1.Id, th.Team1.Id, mattermostModel.ChannelTypePrivate)
 	require.NoError(t, err)
+	dmChannel, err := th.CreateDirectMessageChannel(th.User1, th.User2)
+	require.NoError(t, err)
+	groupDM, err := th.CreateChannel("group-dm", th.User1.Id, th.Team1.Id, mattermostModel.ChannelTypeGroup)
+	require.NoError(t, err)
 
 	require.NoError(t, th.mmStore.ChannelMemberHistory().LogJoinEvent(th.User1.Id, openChannel.Id, start+1000))
 	require.NoError(t, th.mmStore.ChannelMemberHistory().LogJoinEvent(th.User1.Id, privateChannel.Id, start+1000))
+	require.NoError(t, th.mmStore.ChannelMemberHistory().LogJoinEvent(th.User1.Id, groupDM.Id, start+1000))
+	require.NoError(t, th.mmStore.ChannelMemberHistory().LogJoinEvent(th.User1.Id, dmChannel.Id, start+1000))
 
 	// Check channel IDs
 	channelIDs, err := th.Store.GetChannelIDsForUserDuring(th.User1.Id, start, end, true)
 	require.NoError(t, err)
-	require.ElementsMatch(t, channelIDs, []string{privateChannel.Id})
+	require.ElementsMatch(t, channelIDs, []string{privateChannel.Id, dmChannel.Id, groupDM.Id})
 }
 
 func TestSQLStore_LegalHold_GetFileInfosByIDs(t *testing.T) {

--- a/server/store/sqlstore/testhelper.go
+++ b/server/store/sqlstore/testhelper.go
@@ -131,11 +131,15 @@ func (th *TestHelper) CreateTeams(num int, namePrefix string) ([]*model.Team, er
 	return teams, nil
 }
 
-func (th *TestHelper) CreateChannel(name string, userID string, teamID string) (*model.Channel, error) {
+func (th *TestHelper) CreateOpenChannel(name string, userID string, teamID string) (*model.Channel, error) {
+	return th.CreateChannel(name, userID, teamID, model.ChannelTypeOpen)
+}
+
+func (th *TestHelper) CreateChannel(name, userID, teamID string, channelType model.ChannelType) (*model.Channel, error) {
 	channel := &model.Channel{
 		Name:        name,
 		DisplayName: name,
-		Type:        model.ChannelTypeOpen,
+		Type:        channelType,
 		CreatorId:   userID,
 		TeamId:      teamID,
 	}

--- a/webapp/src/components/create_legal_hold_form.scss
+++ b/webapp/src/components/create_legal_hold_form.scss
@@ -7,10 +7,3 @@
     width: 1em;
     height: 1em;
 }
-
-.create-legal-hold-checkbox-wrapper, .create-legal-hold-checkbox-wrapper:focus {
-    border: 0px !important;
-}
-
-.create-legal-hold-container {
-}

--- a/webapp/src/components/create_legal_hold_form.scss
+++ b/webapp/src/components/create_legal_hold_form.scss
@@ -2,5 +2,15 @@
     border: none !important;
 }
 
+.create-legal-hold-checkbox {
+    float: left;
+    width: 1em;
+    height: 1em;
+}
+
+.create-legal-hold-checkbox-wrapper, .create-legal-hold-checkbox-wrapper:focus {
+    border: 0px !important;
+}
+
 .create-legal-hold-container {
 }

--- a/webapp/src/components/create_legal_hold_form.tsx
+++ b/webapp/src/components/create_legal_hold_form.tsx
@@ -150,16 +150,15 @@ const CreateLegalHoldForm = (props: CreateLegalHoldFormProps) => {
                             columnGap: '20px',
                         }}
                     >
+                        <input
+                            type='checkbox'
+                            id='legal-hold-exclude-public-channels'
+                            checked={excludePublicChannels}
+                            onChange={excludePublicChannelsChanged}
+                            className={'create-legal-hold-checkbox'}
+                        />
                         <label htmlFor={'legal-hold-exclude-public-channels'}>
                             {'Exclude public channels'}
-                            <Input
-                                type='checkbox'
-                                id='legal-hold-exclude-public-channels'
-                                checked={excludePublicChannels}
-                                onChange={excludePublicChannelsChanged}
-                                inputClassName={'create-legal-hold-checkbox'}
-                                wrapperClassName={'create-legal-hold-checkbox-wrapper'}
-                            />
                         </label>
                     </div>
                     <div

--- a/webapp/src/components/create_legal_hold_form.tsx
+++ b/webapp/src/components/create_legal_hold_form.tsx
@@ -6,7 +6,6 @@ import UsersInput from '@/components/users_input';
 import {CreateLegalHold} from '@/types';
 import {GenericModal} from '@/components/mattermost-webapp/generic_modal/generic_modal';
 import Input from '@/components/mattermost-webapp/input/input';
-import Select from 'react-select';
 
 import './create_legal_hold_form.scss';
 
@@ -14,7 +13,6 @@ interface CreateLegalHoldFormProps {
     createLegalHold: (data: CreateLegalHold) => Promise<any>;
     onExited: () => void;
     visible: boolean;
-    excludePublicChannels: boolean;
 }
 
 const CreateLegalHoldForm = (props: CreateLegalHoldFormProps) => {
@@ -23,7 +21,7 @@ const CreateLegalHoldForm = (props: CreateLegalHoldFormProps) => {
     const [startsAt, setStartsAt] = useState('');
     const [endsAt, setEndsAt] = useState('');
     const [saving, setSaving] = useState(false);
-    const [excludePublicChannels, setExcludePublicChannels] = useState(props.excludePublicChannels);
+    const [excludePublicChannels, setExcludePublicChannels] = useState(false);
     const [serverError, setServerError] = useState('');
 
     const displayNameChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -66,7 +64,7 @@ const CreateLegalHoldForm = (props: CreateLegalHoldFormProps) => {
             name: slugify(displayName),
         };
 
-        props.createLegalHold(data).then((response) => {
+        props.createLegalHold(data).then((_) => {
             resetForm();
             props.onExited();
         }).catch((error) => {

--- a/webapp/src/components/create_legal_hold_form.tsx
+++ b/webapp/src/components/create_legal_hold_form.tsx
@@ -6,6 +6,7 @@ import UsersInput from '@/components/users_input';
 import {CreateLegalHold} from '@/types';
 import {GenericModal} from '@/components/mattermost-webapp/generic_modal/generic_modal';
 import Input from '@/components/mattermost-webapp/input/input';
+import Select from 'react-select';
 
 import './create_legal_hold_form.scss';
 
@@ -13,6 +14,7 @@ interface CreateLegalHoldFormProps {
     createLegalHold: (data: CreateLegalHold) => Promise<any>;
     onExited: () => void;
     visible: boolean;
+    excludePublicChannels: boolean;
 }
 
 const CreateLegalHoldForm = (props: CreateLegalHoldFormProps) => {
@@ -21,6 +23,7 @@ const CreateLegalHoldForm = (props: CreateLegalHoldFormProps) => {
     const [startsAt, setStartsAt] = useState('');
     const [endsAt, setEndsAt] = useState('');
     const [saving, setSaving] = useState(false);
+    const [excludePublicChannels, setExcludePublicChannels] = useState(props.excludePublicChannels);
     const [serverError, setServerError] = useState('');
 
     const displayNameChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -33,6 +36,10 @@ const CreateLegalHoldForm = (props: CreateLegalHoldFormProps) => {
 
     const endsAtChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
         setEndsAt(e.target.value);
+    };
+
+    const excludePublicChannelsChanged: (e: React.ChangeEvent<HTMLInputElement>) => void = (e) => {
+        setExcludePublicChannels(e.target.checked);
     };
 
     const resetForm = () => {
@@ -55,6 +62,7 @@ const CreateLegalHoldForm = (props: CreateLegalHoldFormProps) => {
             ends_at: (new Date(endsAt)).getTime(),
             starts_at: (new Date(startsAt)).getTime(),
             display_name: displayName,
+            exclude_public_channels: excludePublicChannels,
             name: slugify(displayName),
         };
 
@@ -144,6 +152,24 @@ const CreateLegalHoldForm = (props: CreateLegalHoldFormProps) => {
                             columnGap: '20px',
                         }}
                     >
+                        <label htmlFor={'legal-hold-exclude-public-channels'}>
+                            {'Exclude public channels'}
+                            <Input
+                                type='checkbox'
+                                id='legal-hold-exclude-public-channels'
+                                checked={excludePublicChannels}
+                                onChange={excludePublicChannelsChanged}
+                                inputClassName={'create-legal-hold-checkbox'}
+                                wrapperClassName={'create-legal-hold-checkbox-wrapper'}
+                            />
+                        </label>
+                    </div>
+                    <div
+                        style={{
+                            display: 'flex',
+                            columnGap: '20px',
+                        }}
+                    >
                         <Input
                             type='date'
                             autoComplete='off'
@@ -189,4 +215,3 @@ const slugify = (data: string) => {
 };
 
 export default CreateLegalHoldForm;
-

--- a/webapp/src/components/update_legal_hold_form/update_legal_hold_form.tsx
+++ b/webapp/src/components/update_legal_hold_form/update_legal_hold_form.tsx
@@ -177,16 +177,15 @@ const UpdateLegalHoldForm = (props: UpdateLegalHoldFormProps) => {
                             columnGap: '20px',
                         }}
                     >
+                        <input
+                            type='checkbox'
+                            id='legal-hold-exclude-public-channels'
+                            checked={excludePublicChannels}
+                            onChange={excludePublicChannelsChanged}
+                            className={'create-legal-hold-checkbox'}
+                        />
                         <label htmlFor={'legal-hold-exclude-public-channels'}>
                             {'Exclude public channels'}
-                            <Input
-                                type='checkbox'
-                                id='legal-hold-exclude-public-channels'
-                                checked={excludePublicChannels}
-                                onChange={excludePublicChannelsChanged}
-                                inputClassName={'create-legal-hold-checkbox'}
-                                wrapperClassName={'create-legal-hold-checkbox-wrapper'}
-                            />
                         </label>
                     </div>
                     <div

--- a/webapp/src/components/update_legal_hold_form/update_legal_hold_form.tsx
+++ b/webapp/src/components/update_legal_hold_form/update_legal_hold_form.tsx
@@ -91,7 +91,7 @@ const UpdateLegalHoldForm = (props: UpdateLegalHoldFormProps) => {
             display_name: displayName,
         };
 
-        props.updateLegalHold(data).then((_) => {
+        props.updateLegalHold(data).then(() => {
             resetForm();
             props.onExited();
         }).catch((error) => {

--- a/webapp/src/components/update_legal_hold_form/update_legal_hold_form.tsx
+++ b/webapp/src/components/update_legal_hold_form/update_legal_hold_form.tsx
@@ -25,6 +25,7 @@ const UpdateLegalHoldForm = (props: UpdateLegalHoldFormProps) => {
     const [startsAt, setStartsAt] = useState('');
     const [endsAt, setEndsAt] = useState('');
     const [saving, setSaving] = useState(false);
+    const [excludePublicChannels, setExcludePublicChannels] = useState(false);
     const [serverError, setServerError] = useState('');
 
     const displayNameChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -33,6 +34,10 @@ const UpdateLegalHoldForm = (props: UpdateLegalHoldFormProps) => {
 
     const endsAtChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
         setEndsAt(e.target.value);
+    };
+
+    const excludePublicChannelsChanged: (e: React.ChangeEvent<HTMLInputElement>) => void = (e) => {
+        setExcludePublicChannels(e.target.checked);
     };
 
     const resetForm = () => {
@@ -54,6 +59,7 @@ const UpdateLegalHoldForm = (props: UpdateLegalHoldFormProps) => {
             setId(props.legalHold.id);
             setDisplayName(props.legalHold?.display_name);
             setUsers(props.users);
+            setExcludePublicChannels(props.legalHold.exclude_public_channels);
 
             if (props.legalHold.starts_at) {
                 const startsAtString = dayjs(props.legalHold.starts_at).format('YYYY-MM-DD');
@@ -81,10 +87,11 @@ const UpdateLegalHoldForm = (props: UpdateLegalHoldFormProps) => {
             id: props.legalHold.id,
             user_ids: users.map((user) => user.id),
             ends_at: (new Date(endsAt)).getTime(),
+            exclude_public_channels: excludePublicChannels,
             display_name: displayName,
         };
 
-        props.updateLegalHold(data).then((response) => {
+        props.updateLegalHold(data).then((_) => {
             resetForm();
             props.onExited();
         }).catch((error) => {
@@ -163,6 +170,24 @@ const UpdateLegalHoldForm = (props: UpdateLegalHoldFormProps) => {
                             users={users}
                             onChange={setUsers}
                         />
+                    </div>
+                    <div
+                        style={{
+                            display: 'flex',
+                            columnGap: '20px',
+                        }}
+                    >
+                        <label htmlFor={'legal-hold-exclude-public-channels'}>
+                            {'Exclude public channels'}
+                            <Input
+                                type='checkbox'
+                                id='legal-hold-exclude-public-channels'
+                                checked={excludePublicChannels}
+                                onChange={excludePublicChannelsChanged}
+                                inputClassName={'create-legal-hold-checkbox'}
+                                wrapperClassName={'create-legal-hold-checkbox-wrapper'}
+                            />
+                        </label>
                     </div>
                     <div
                         style={{

--- a/webapp/src/types/index.d.ts
+++ b/webapp/src/types/index.d.ts
@@ -5,6 +5,7 @@ export interface LegalHold {
     starts_at: number;
     ends_at: number;
     user_ids: string[];
+    exclude_public_channels: boolean;
 }
 
 export interface CreateLegalHold {


### PR DESCRIPTION
#### Summary
Adds a new option to legal holds to avoid storing data from public channels

- [x] Adds `LegalHold.ExcludePublicChannels`
- [x] Modified signature of `GetChannelIDsForUserDuring` adding one parameter. (Probably better to refactor it using an `Opts` struct)
- [x] Modified the creation form to allow checking this option
- [x] Modified the edit form to allow checking this option (changes would only apply from the moment the change is made)
- [x] Better UI


#### Screenshots 
![Screenshot 2024-06-06 at 16 13 37](https://github.com/mattermost/mattermost-plugin-legal-hold/assets/812088/02d823d8-95c9-4346-9d3f-13f550c5180d)

Closes #55 

