### PR TITLE
Explain in README how to run the legal hold job on demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,14 @@ permanently purged from the storage area, and cannot be recovered.
 See the `processor` subdirectory for how to turn the downloaded zip file into a human readable HTML
 export that you can view and search in a web browser.
 
-## A note on downlading large legal holds
+## A note on downloading large legal holds
 
 For large legal holds, the download process can take more time than the HTTP request timeout. If you are experiencing timeouts, you can increase the timeout under **System Console** > **Web server** > **Write timeout** or in your `config.json` file. This is a global setting for the entire server.
 
 Keep in mind that the same applies for reverse proxies, which may have their own timeout settings. If you are using a reverse proxy, you may need to adjust the timeout settings there as well.
+
+## Development
+
+In order to run the plugin's scheduled job on demand for testing, you can send a request to the `/api/v1/legalhold/run` endpoint, as explained in this pull request: https://github.com/mattermost/mattermost-plugin-legal-hold/pull/43
+
+This plugin contains both a server and web app portion. Read our documentation about the [Developer Workflow](https://developers.mattermost.com/integrate/plugins/developer-workflow/) and [Developer Setup](https://developers.mattermost.com/integrate/plugins/developer-setup/) for more information about developing and extending plugins.


### PR DESCRIPTION
#### Summary

There was a feature added for demoing the plugin, to run the plugin's scheduled job on demand, rather than waiting until the next run of the job https://github.com/mattermost/mattermost-plugin-legal-hold/pull/43. In order to surface this available functionality for development and testing purposes, this PR explains this feature in the README.

Context for this PR https://github.com/mattermost/mattermost-plugin-legal-hold/issues/69#issuecomment-2176461581