### PR TITLE
Remove parentheses from legal hold folder path to work on MM Cloud servers

### DIFF
--- a/server/model/legal_hold.go
+++ b/server/model/legal_hold.go
@@ -128,7 +128,7 @@ func (lh *LegalHold) IsFinished() bool {
 
 // BasePath returns the base file storage path for this legal hold.
 func (lh *LegalHold) BasePath() string {
-	return fmt.Sprintf("legal_hold/%s_(%s)", lh.Name, lh.ID)
+	return fmt.Sprintf("legal_hold/%s_%s", lh.Name, lh.ID)
 }
 
 // CreateLegalHold holds the data that is specified in the API call to create a LegalHold.

--- a/server/model/legal_hold_test.go
+++ b/server/model/legal_hold_test.go
@@ -405,8 +405,8 @@ func TestModel_LegalHold_BasePath(t *testing.T) {
 		lh       *LegalHold
 		expected string
 	}{
-		{&LegalHold{Name: "testhold", ID: "1"}, "legal_hold/testhold_(1)"},
-		{&LegalHold{Name: "anotherhold", ID: "2"}, "legal_hold/anotherhold_(2)"},
+		{&LegalHold{Name: "testhold", ID: "1"}, "legal_hold/testhold_1"},
+		{&LegalHold{Name: "anotherhold", ID: "2"}, "legal_hold/anotherhold_2"},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
#### Summary

On MM cloud servers, this plugin returned no data when downloading the legal hold data from the UI. It produces an empty zip file as noted in https://github.com/mattermost/mattermost-plugin-legal-hold/issues/69

Upon debugging this, I found that having parentheses in the folder path makes it incompatible with the cloud server's file backend. I believe this has to do with this server's usage of `bifrost` https://github.com/mattermost/bifrost. In the case of using the parenthese (i.e. before the changes in this PR), I've verified that the files are correctly written and read from, though the call to `p.FileBackend.ListDirectoryRecursively(legalHold.BasePath())` [here](https://github.com/mattermost/mattermost-plugin-legal-hold/blob/0afda796c5a9d13bf510e9b987356eadde8efdc1/server/api.go#L236) returns an empty array of strings in the case of using parentheses and running on the MM Cloud server.

This PR changes the directory where a given legal hold's files are stored in S3/local. The original format was:

```go
fmt.Sprintf("legal_hold/%s_(%s)", lh.Name, lh.ID)
```

and has been changed to

```go
fmt.Sprintf("legal_hold/%s_%s", lh.Name, lh.ID)
```

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-legal-hold/issues/69