### PR TITLE
Bump version to 0.4.0-alpha

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
   "support_url": "https://github.com/mattermost/mattermost-plugin-legal-hold/issues",
   "release_notes_url": "https://github.com/mattermost/mattermost-plugin-legal-hold/releases/tag/v0.3.4",
   "icon_path": "assets/starter-template-icon.svg",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "min_server_version": "6.2.1",
   "server": {
     "executables": {


### PR DESCRIPTION
#### Summary
Bumps plugin version to 0.4.0 to match release:  https://github.com/mattermost/mattermost-plugin-legal-hold/releases/tag/v0.4.0

#### Ticket Link
NONE