### PR TITLE
GH-85 Include dependencies array in useEffect for all components

### DIFF
--- a/webapp/src/components/legal_hold_table/legal_hold_table.tsx
+++ b/webapp/src/components/legal_hold_table/legal_hold_table.tsx
@@ -1,7 +1,7 @@
-import React, {useEffect} from 'react';
+import React, { useEffect } from 'react';
 
 import LegalHoldRow from '@/components/legal_hold_table/legal_hold_row';
-import {LegalHold} from '@/types';
+import { LegalHold } from '@/types';
 
 interface LegalHoldTableProps {
     legalHolds: LegalHold[];
@@ -25,7 +25,7 @@ const LegalHoldTable = (props: LegalHoldTableProps) => {
         props.actions.getMissingProfilesByIds(
             user_ids,
         );
-    });
+    }, [props.actions, user_ids]);
 
     return (
         <div>

--- a/webapp/src/components/legal_hold_table/legal_hold_table.tsx
+++ b/webapp/src/components/legal_hold_table/legal_hold_table.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect } from 'react';
+import React, {useEffect} from 'react';
 
 import LegalHoldRow from '@/components/legal_hold_table/legal_hold_row';
-import { LegalHold } from '@/types';
+import {LegalHold} from '@/types';
 
 interface LegalHoldTableProps {
     legalHolds: LegalHold[];

--- a/webapp/src/components/legal_holds_setting.tsx
+++ b/webapp/src/components/legal_holds_setting.tsx
@@ -5,13 +5,13 @@ import {IntlProvider} from 'react-intl';
 import Client from '@/client';
 import {CreateLegalHold, LegalHold, UpdateLegalHold} from '@/types';
 
+import CreateLegalHoldButton from '@/components/create_legal_hold_button';
 import CreateLegalHoldForm from '@/components/create_legal_hold_form';
 import LegalHoldTable from '@/components/legal_hold_table';
-import CreateLegalHoldButton from '@/components/create_legal_hold_button';
 
+import ConfirmRelease from '@/components/confirm_release';
 import LegalHoldIcon from '@/components/legal_hold_icon.svg';
 import UpdateLegalHoldForm from '@/components/update_legal_hold_form';
-import ConfirmRelease from '@/components/confirm_release';
 
 const LegalHoldsSetting = () => {
     const [legalHoldsFetched, setLegalHoldsFetched] = useState(false);
@@ -83,7 +83,7 @@ const LegalHoldsSetting = () => {
         if (!legalHoldsFetched && !legalHoldsFetching) {
             fetchLegalHolds().catch(console.error); //eslint-disable-line no-console
         }
-    });
+    }, [legalHoldsFetched, legalHoldsFetching]);
 
     return (
         <IntlProvider locale='en-US'>

--- a/webapp/src/components/mattermost-webapp/input/input.tsx
+++ b/webapp/src/components/mattermost-webapp/input/input.tsx
@@ -3,7 +3,7 @@
 // @ts-nocheck
 
 import classNames from 'classnames';
-import React, {useState, useEffect} from 'react';
+import React, {useEffect, useState} from 'react';
 import {useIntl} from 'react-intl';
 
 import {CloseCircleIcon} from '@mattermost/compass-icons/components';
@@ -93,7 +93,7 @@ const Input = React.forwardRef((
         if (customMessage !== undefined && customMessage !== null && Boolean(customMessage.value)) { // eslint-disable-line no-undefined
             setCustomInputLabel(customMessage);
         }
-    }, [customMessage]);
+    }, [customMessage, customInputLabel]);
 
     const handleOnFocus = (event: React.FocusEvent<HTMLInputElement>) => {
         setFocused(true);

--- a/webapp/src/components/update_legal_hold_form/update_legal_hold_form.tsx
+++ b/webapp/src/components/update_legal_hold_form/update_legal_hold_form.tsx
@@ -1,12 +1,12 @@
-import React, {useEffect, useState} from 'react';
 import dayjs from 'dayjs';
+import React, {useEffect, useState} from 'react';
 
 import {UserProfile} from 'mattermost-redux/types/users';
 
-import UsersInput from '@/components/users_input';
-import {LegalHold, UpdateLegalHold} from '@/types';
 import {GenericModal} from '@/components/mattermost-webapp/generic_modal/generic_modal';
 import Input from '@/components/mattermost-webapp/input/input';
+import UsersInput from '@/components/users_input';
+import {LegalHold, UpdateLegalHold} from '@/types';
 
 import '../create_legal_hold_form.scss';
 
@@ -71,7 +71,7 @@ const UpdateLegalHoldForm = (props: UpdateLegalHoldFormProps) => {
                 setEndsAt(endsAtString);
             }
         }
-    }, [props.legalHold, props.users, props.visible]);
+    }, [props.legalHold, props.users, props.visible, id]);
 
     const onSave = () => {
         if (saving) {


### PR DESCRIPTION
#### Summary
The LegalHoldTable component was missing a dependency array in a `useEffect` hook.  This caused the hook to be called on every render.  

Additional dependencies were added to other components based on linter errors.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-legal-hold/issues/85

