### PR TITLE
[GH-94] Disable S3 settings if AWS config is invalid

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -57,12 +57,12 @@ type Plugin struct {
 
 func (p *Plugin) OnActivate() error {
 	// Check for an enterprise license or a development environment
-	// config := p.API.GetConfig()
-	// license := p.API.GetLicense()
+	config := p.API.GetConfig()
+	license := p.API.GetLicense()
 
-	// if !pluginapi.IsEnterpriseLicensedOrDevelopment(config, license) {
-	// 	return fmt.Errorf("this plugin requires an Enterprise license")
-	// }
+	if !pluginapi.IsEnterpriseLicensedOrDevelopment(config, license) {
+		return fmt.Errorf("this plugin requires an Enterprise license")
+	}
 
 	// Create plugin API client
 	p.Client = pluginapi.NewClient(p.API, p.Driver)

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -177,7 +177,7 @@ func (p *Plugin) Reconfigure() error {
 	if err = filesBackend.TestConnection(); err != nil {
 		pluginConfig := p.Client.Configuration.GetPluginConfig()
 
-		// Disableling the AWS setting in case the AWS config is invalid
+		// Disable the S3 settings in case the AWS config is invalid
 		pluginConfig["amazons3bucketsettings"].(map[string]interface{})["Enable"] = false
 
 		confErr := p.Client.Configuration.SavePluginConfig(pluginConfig)


### PR DESCRIPTION
#### Summary
- Disable AWS settings if AWS config is invalid

#### How to test?
1. Enable S3 settings and add a invalid config
2. Save the config
3. Refresh the page, the S3 settings should be disabled.

#### Ticket Link
Fixes #94 

