### PR TITLE
fix: including public channels should check for compliance settings

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -93,7 +93,9 @@ func (p *Plugin) createLegalHold(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := legalHold.IsValidForCreate(config); err != nil {
+	mmConfigComplianceEnabled := config.ComplianceSettings.Enable != nil && *config.ComplianceSettings.Enable
+
+	if err := legalHold.IsValidForCreate(mmConfigComplianceEnabled); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -194,7 +196,9 @@ func (p *Plugin) updateLegalHold(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err = updateLegalHold.IsValid(config); err != nil {
+	mmConfigComplianceEnabled := config.ComplianceSettings.Enable != nil && *config.ComplianceSettings.Enable
+
+	if err = updateLegalHold.IsValid(mmConfigComplianceEnabled); err != nil {
 		http.Error(w, "LegalHold update data is not valid", http.StatusBadRequest)
 		p.Client.Log.Error(err.Error())
 		return

--- a/server/model/legal_hold.go
+++ b/server/model/legal_hold.go
@@ -98,7 +98,7 @@ func (lh *LegalHold) IsValidForCreate(mmConfigComplianceEnabled bool) error {
 	}
 
 	if !lh.ExcludePublicChannels && !mmConfigComplianceEnabled {
-		return errors.New("Compliance must be enabled on the Mattermost server in order to include public channels in a LegalHold")
+		return errors.New("Compliance monitoring must be enabled on the Mattermost server in order to include public channels in a LegalHold")
 	}
 
 	return nil
@@ -194,7 +194,7 @@ func (ulh UpdateLegalHold) IsValid(mmConfigComplianceEnabled bool) error {
 	}
 
 	if !ulh.ExcludePublicChannels && !mmConfigComplianceEnabled {
-		return errors.New("Compliance must be enabled on the Mattermost server in order to include public channels in a LegalHold")
+		return errors.New("Compliance monitoring must be enabled on the Mattermost server in order to include public channels in a LegalHold")
 	}
 
 	if ulh.EndsAt < 0 {

--- a/server/model/legal_hold.go
+++ b/server/model/legal_hold.go
@@ -3,7 +3,6 @@ package model
 import (
 	"fmt"
 
-	"github.com/mattermost/mattermost-server/v6/model"
 	mattermostModel "github.com/mattermost/mattermost-server/v6/model"
 	"github.com/pkg/errors"
 
@@ -59,7 +58,7 @@ func (lh *LegalHold) DeepCopy() LegalHold {
 // failure. It does not guarantee that creation in the store will be successful,
 // as other issues such as non-unique ID value can still cause the LegalHold to
 // fail to save.
-func (lh *LegalHold) IsValidForCreate(config *model.Config) error {
+func (lh *LegalHold) IsValidForCreate(config *mattermostModel.Config) error {
 	if !mattermostModel.IsValidId(lh.ID) {
 		return fmt.Errorf("LegalHold ID is not valid: %s", lh.ID)
 	}
@@ -175,7 +174,7 @@ type UpdateLegalHold struct {
 	EndsAt                int64    `json:"ends_at"`
 }
 
-func (ulh UpdateLegalHold) IsValid(config *model.Config) error {
+func (ulh UpdateLegalHold) IsValid(config *mattermostModel.Config) error {
 	if !mattermostModel.IsValidId(ulh.ID) {
 		return fmt.Errorf("LegalHold ID is not valid: %s", ulh.ID)
 	}

--- a/server/model/legal_hold.go
+++ b/server/model/legal_hold.go
@@ -58,7 +58,7 @@ func (lh *LegalHold) DeepCopy() LegalHold {
 // failure. It does not guarantee that creation in the store will be successful,
 // as other issues such as non-unique ID value can still cause the LegalHold to
 // fail to save.
-func (lh *LegalHold) IsValidForCreate(config *mattermostModel.Config) error {
+func (lh *LegalHold) IsValidForCreate(mmConfigComplianceEnabled bool) error {
 	if !mattermostModel.IsValidId(lh.ID) {
 		return fmt.Errorf("LegalHold ID is not valid: %s", lh.ID)
 	}
@@ -97,7 +97,7 @@ func (lh *LegalHold) IsValidForCreate(config *mattermostModel.Config) error {
 		return errors.New("LegalHold must end after it starts")
 	}
 
-	if !lh.ExcludePublicChannels && (config.ComplianceSettings.Enable == nil || !*config.ComplianceSettings.Enable) {
+	if !lh.ExcludePublicChannels && !mmConfigComplianceEnabled {
 		return errors.New("Compliance must be enabled on the Mattermost server in order to include public channels in a LegalHold")
 	}
 
@@ -174,7 +174,7 @@ type UpdateLegalHold struct {
 	EndsAt                int64    `json:"ends_at"`
 }
 
-func (ulh UpdateLegalHold) IsValid(config *mattermostModel.Config) error {
+func (ulh UpdateLegalHold) IsValid(mmConfigComplianceEnabled bool) error {
 	if !mattermostModel.IsValidId(ulh.ID) {
 		return fmt.Errorf("LegalHold ID is not valid: %s", ulh.ID)
 	}
@@ -193,7 +193,7 @@ func (ulh UpdateLegalHold) IsValid(config *mattermostModel.Config) error {
 		}
 	}
 
-	if !ulh.ExcludePublicChannels && (config.ComplianceSettings.Enable == nil || !*config.ComplianceSettings.Enable) {
+	if !ulh.ExcludePublicChannels && !mmConfigComplianceEnabled {
 		return errors.New("Compliance must be enabled on the Mattermost server in order to include public channels in a LegalHold")
 	}
 

--- a/server/model/legal_hold_test.go
+++ b/server/model/legal_hold_test.go
@@ -70,12 +70,13 @@ func TestModel_LegalHold_IsValidForCreate(t *testing.T) {
 		{
 			name: "Valid",
 			lh: &LegalHold{
-				ID:          mattermostModel.NewId(),
-				Name:        "legalhold1",
-				DisplayName: "Test Legal Hold",
-				UserIDs:     []string{mattermostModel.NewId(), mattermostModel.NewId()},
-				StartsAt:    10,
-				EndsAt:      0,
+				ID:                    mattermostModel.NewId(),
+				Name:                  "legalhold1",
+				DisplayName:           "Test Legal Hold",
+				UserIDs:               []string{mattermostModel.NewId(), mattermostModel.NewId()},
+				ExcludePublicChannels: true,
+				StartsAt:              10,
+				EndsAt:                0,
 			},
 			wantErr: false,
 		},
@@ -269,14 +270,9 @@ func TestModel_LegalHold_IsValidForCreate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Default mmConfig set compliance to true, since exclude public channels is false by default
-			// in code.
+			// Provide non-nil default value for mmConfig
 			if tt.mmConfig == nil {
-				tt.mmConfig = &mattermostModel.Config{
-					ComplianceSettings: mattermostModel.ComplianceSettings{
-						Enable: mattermostModel.NewBool(true),
-					},
-				}
+				tt.mmConfig = &mattermostModel.Config{}
 			}
 
 			err := tt.lh.IsValidForCreate(tt.mmConfig)
@@ -504,10 +500,11 @@ func TestModel_UpdateLegalHold_IsValid(t *testing.T) {
 		{
 			name: "Valid",
 			ulh: UpdateLegalHold{
-				ID:          model.NewId(),
-				DisplayName: "TestName",
-				UserIDs:     []string{model.NewId()},
-				EndsAt:      0,
+				ID:                    model.NewId(),
+				DisplayName:           "TestName",
+				UserIDs:               []string{model.NewId()},
+				EndsAt:                0,
+				ExcludePublicChannels: true,
 			},
 			expected: "",
 		},
@@ -554,10 +551,11 @@ func TestModel_UpdateLegalHold_IsValid(t *testing.T) {
 		{
 			name: "NegativeEndsAt",
 			ulh: UpdateLegalHold{
-				ID:          model.NewId(),
-				DisplayName: "TestName",
-				UserIDs:     []string{model.NewId()},
-				EndsAt:      -1,
+				ID:                    model.NewId(),
+				DisplayName:           "TestName",
+				UserIDs:               []string{model.NewId()},
+				ExcludePublicChannels: true,
+				EndsAt:                -1,
 			},
 			expected: "LegalHold must end at a valid time or zero",
 		},
@@ -580,14 +578,9 @@ func TestModel_UpdateLegalHold_IsValid(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			// Default mmConfig set compliance to true, since exclude public channels is false by default
-			// in code.
+			// Provide non-nil default value for mmConfig
 			if testCase.mmConfig == nil {
-				testCase.mmConfig = &mattermostModel.Config{
-					ComplianceSettings: mattermostModel.ComplianceSettings{
-						Enable: mattermostModel.NewBool(true),
-					},
-				}
+				testCase.mmConfig = &mattermostModel.Config{}
 			}
 
 			err := testCase.ulh.IsValid(testCase.mmConfig)

--- a/server/model/legal_hold_test.go
+++ b/server/model/legal_hold_test.go
@@ -537,7 +537,7 @@ func TestModel_UpdateLegalHold_IsValid(t *testing.T) {
 				ExcludePublicChannels: false,
 			},
 			mmConfigComplianceEnabled: false,
-			expected:                  "Compliance must be enabled on the Mattermost server in order to include public channels in a LegalHold",
+			expected:                  "Compliance monitoring must be enabled on the Mattermost server in order to include public channels in a LegalHold",
 		},
 		{
 			name: "Include public channels and compliance enabled",

--- a/server/model/legal_hold_test.go
+++ b/server/model/legal_hold_test.go
@@ -529,7 +529,7 @@ func TestModel_UpdateLegalHold_IsValid(t *testing.T) {
 			expected: "LegalHold must end at a valid time or zero",
 		},
 		{
-			name: "Include public channels and compliance disabled",
+			name: "Include public channels and compliance disabled",
 			ulh: UpdateLegalHold{
 				ID:                    mattermostModel.NewId(),
 				UserIDs:               []string{mattermostModel.NewId()},

--- a/server/store/kvstore/legal_hold.go
+++ b/server/store/kvstore/legal_hold.go
@@ -82,10 +82,6 @@ func (kvs Impl) GetLegalHoldByID(id string) (*model.LegalHold, error) {
 }
 
 func (kvs Impl) UpdateLegalHold(lh, oldValue model.LegalHold) (*model.LegalHold, error) {
-	if !mattermostModel.IsValidId(lh.ID) {
-		return nil, fmt.Errorf("legal hold does not have a valid id")
-	}
-
 	lh.UpdateAt = mattermostModel.GetMillis()
 
 	key := fmt.Sprintf("%s%s", legalHoldPrefix, lh.ID)

--- a/server/store/kvstore/legal_hold.go
+++ b/server/store/kvstore/legal_hold.go
@@ -26,10 +26,6 @@ func NewKVStore(client *pluginapi.Client) KVStore {
 }
 
 func (kvs Impl) CreateLegalHold(lh model.LegalHold) (*model.LegalHold, error) {
-	if err := lh.IsValidForCreate(); err != nil {
-		return nil, errors.Wrap(err, "LegalHold is not valid for create")
-	}
-
 	lh.CreateAt = mattermostModel.GetMillis()
 	lh.UpdateAt = lh.CreateAt
 	lh.Secret = mattermostModel.NewId()
@@ -86,8 +82,8 @@ func (kvs Impl) GetLegalHoldByID(id string) (*model.LegalHold, error) {
 }
 
 func (kvs Impl) UpdateLegalHold(lh, oldValue model.LegalHold) (*model.LegalHold, error) {
-	if err := lh.IsValidForCreate(); err != nil {
-		return nil, errors.Wrap(err, "LegalHold is not valid for create")
+	if !mattermostModel.IsValidId(lh.ID) {
+		return nil, fmt.Errorf("legal hold does not have a valid id")
 	}
 
 	lh.UpdateAt = mattermostModel.GetMillis()

--- a/server/store/kvstore/legal_hold_test.go
+++ b/server/store/kvstore/legal_hold_test.go
@@ -201,21 +201,6 @@ func TestKVStore_UpdateLegalHold(t *testing.T) {
 	assert.Equal(t, lh3.ExecutionLength, lh2.ExecutionLength)
 	assert.NotEqual(t, lh3.UpdateAt, lh2.UpdateAt)
 	assert.Equal(t, lh3.CreateAt, lh2.UpdateAt)
-
-	// TODO: This test was supposed to test that the legal hold did not exist previously, but in reality what it did
-	// was failing when the ID was not valid.
-	t.Run("invalid id", func(t *testing.T) {
-		// Test updating a legal hold that does not exist
-		lh4 := model.LegalHold{
-			ID:          "doesnotexist",
-			Name:        "legal-hold-4",
-			DisplayName: "Legal Hold 4",
-			UserIDs:     []string{mattermostModel.NewId()},
-			StartsAt:    mattermostModel.GetMillis(),
-		}
-		_, err = kvstore.UpdateLegalHold(lh4, *lh3)
-		require.Error(t, err)
-	})
 }
 
 func TestKVStore_DeleteLegalHold(t *testing.T) {

--- a/server/store/kvstore/legal_hold_test.go
+++ b/server/store/kvstore/legal_hold_test.go
@@ -202,16 +202,20 @@ func TestKVStore_UpdateLegalHold(t *testing.T) {
 	assert.NotEqual(t, lh3.UpdateAt, lh2.UpdateAt)
 	assert.Equal(t, lh3.CreateAt, lh2.UpdateAt)
 
-	// Test updating a legal hold that does not exist
-	lh4 := model.LegalHold{
-		ID:          "doesnotexist",
-		Name:        "legal-hold-4",
-		DisplayName: "Legal Hold 4",
-		UserIDs:     []string{mattermostModel.NewId()},
-		StartsAt:    mattermostModel.GetMillis(),
-	}
-	_, err = kvstore.UpdateLegalHold(lh4, *lh3)
-	require.Error(t, err)
+	// TODO: This test was supposed to test that the legal hold did not exist previously, but in reality what it did
+	// was failing when the ID was not valid.
+	t.Run("invalid id", func(t *testing.T) {
+		// Test updating a legal hold that does not exist
+		lh4 := model.LegalHold{
+			ID:          "doesnotexist",
+			Name:        "legal-hold-4",
+			DisplayName: "Legal Hold 4",
+			UserIDs:     []string{mattermostModel.NewId()},
+			StartsAt:    mattermostModel.GetMillis(),
+		}
+		_, err = kvstore.UpdateLegalHold(lh4, *lh3)
+		require.Error(t, err)
+	})
 }
 
 func TestKVStore_DeleteLegalHold(t *testing.T) {


### PR DESCRIPTION
#### Summary
- If the legal hold is created/updated with the exclude public channels disabled (including public channel data) a check is made to ensure that compliance export is enabled
- Added validation in the API layer
- Removed validation from the KVStore layer (since it's redundant and is not checking what we think it is)
- Added a validation for dates (`StartDate < EndDate`)

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-59830