### PR TITLE
chore: change log output

### DIFF
--- a/server/jobs/legal_hold_job.go
+++ b/server/jobs/legal_hold_job.go
@@ -225,7 +225,7 @@ func (j *LegalHoldJob) run() {
 					continue
 				}
 				lh = *newLH
-				j.client.Log.Info(fmt.Sprintf("%v", lh))
+				j.client.Log.Info("legal hold executed", "legal_hold_id", lh.ID, "legal_hold_name", lh.Name)
 			}
 		}
 	}


### PR DESCRIPTION
#### Summary
Changes the log output of the legal hold processor job to display only the ID and the Name of the legal hold being run, instead of the representation of the entire legal hold inside the log message attribute.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-59853