### PR TITLE
chore: use put instead of post for update

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -42,7 +42,7 @@ func (p *Plugin) ServeHTTP(_ *plugin.Context, w http.ResponseWriter, r *http.Req
 	router.HandleFunc("/api/v1/legalhold/list", p.listLegalHolds).Methods(http.MethodGet)
 	router.HandleFunc("/api/v1/legalhold/create", p.createLegalHold).Methods(http.MethodPost)
 	router.HandleFunc("/api/v1/legalhold/{legalhold_id:[A-Za-z0-9]+}/release", p.releaseLegalHold).Methods(http.MethodPost)
-	router.HandleFunc("/api/v1/legalhold/{legalhold_id:[A-Za-z0-9]+}/update", p.updateLegalHold).Methods(http.MethodPost)
+	router.HandleFunc("/api/v1/legalhold/{legalhold_id:[A-Za-z0-9]+}/update", p.updateLegalHold).Methods(http.MethodPut)
 	router.HandleFunc("/api/v1/legalhold/{legalhold_id:[A-Za-z0-9]+}/download", p.downloadLegalHold).Methods(http.MethodGet)
 	router.HandleFunc("/api/v1/test_amazon_s3_connection", p.testAmazonS3Connection).Methods(http.MethodPost)
 

--- a/server/api.go
+++ b/server/api.go
@@ -39,11 +39,11 @@ func (p *Plugin) ServeHTTP(_ *plugin.Context, w http.ResponseWriter, r *http.Req
 	router := mux.NewRouter()
 
 	// Routes called by the plugin's webapp
-	router.HandleFunc("/api/v1/legalhold", p.listLegalHolds).Methods(http.MethodGet)
-	router.HandleFunc("/api/v1/legalhold", p.createLegalHold).Methods(http.MethodPost)
-	router.HandleFunc("/api/v1/legalhold/{legalhold_id:[A-Za-z0-9]+}/release", p.releaseLegalHold).Methods(http.MethodPost)
-	router.HandleFunc("/api/v1/legalhold/{legalhold_id:[A-Za-z0-9]+}", p.updateLegalHold).Methods(http.MethodPut)
-	router.HandleFunc("/api/v1/legalhold/{legalhold_id:[A-Za-z0-9]+}/download", p.downloadLegalHold).Methods(http.MethodGet)
+	router.HandleFunc("/api/v1/legalholds", p.listLegalHolds).Methods(http.MethodGet)
+	router.HandleFunc("/api/v1/legalholds", p.createLegalHold).Methods(http.MethodPost)
+	router.HandleFunc("/api/v1/legalholds/{legalhold_id:[A-Za-z0-9]+}/release", p.releaseLegalHold).Methods(http.MethodPost)
+	router.HandleFunc("/api/v1/legalholds/{legalhold_id:[A-Za-z0-9]+}", p.updateLegalHold).Methods(http.MethodPut)
+	router.HandleFunc("/api/v1/legalholds/{legalhold_id:[A-Za-z0-9]+}/download", p.downloadLegalHold).Methods(http.MethodGet)
 	router.HandleFunc("/api/v1/test_amazon_s3_connection", p.testAmazonS3Connection).Methods(http.MethodPost)
 
 	// Other routes

--- a/server/api.go
+++ b/server/api.go
@@ -39,10 +39,10 @@ func (p *Plugin) ServeHTTP(_ *plugin.Context, w http.ResponseWriter, r *http.Req
 	router := mux.NewRouter()
 
 	// Routes called by the plugin's webapp
-	router.HandleFunc("/api/v1/legalhold/list", p.listLegalHolds).Methods(http.MethodGet)
-	router.HandleFunc("/api/v1/legalhold/create", p.createLegalHold).Methods(http.MethodPost)
+	router.HandleFunc("/api/v1/legalhold", p.listLegalHolds).Methods(http.MethodGet)
+	router.HandleFunc("/api/v1/legalhold", p.createLegalHold).Methods(http.MethodPost)
 	router.HandleFunc("/api/v1/legalhold/{legalhold_id:[A-Za-z0-9]+}/release", p.releaseLegalHold).Methods(http.MethodPost)
-	router.HandleFunc("/api/v1/legalhold/{legalhold_id:[A-Za-z0-9]+}/update", p.updateLegalHold).Methods(http.MethodPut)
+	router.HandleFunc("/api/v1/legalhold/{legalhold_id:[A-Za-z0-9]+}", p.updateLegalHold).Methods(http.MethodPut)
 	router.HandleFunc("/api/v1/legalhold/{legalhold_id:[A-Za-z0-9]+}/download", p.downloadLegalHold).Methods(http.MethodGet)
 	router.HandleFunc("/api/v1/test_amazon_s3_connection", p.testAmazonS3Connection).Methods(http.MethodPost)
 

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -9,26 +9,26 @@ class APIClient {
     private readonly client4 = new Client4();
 
     downloadUrl = (id: string) => {
-        return `${this.url}/legalhold/${id}/download`;
+        return `${this.url}/legalholds/${id}/download`;
     };
 
     getLegalHolds = () => {
-        const url = `${this.url}/legalhold`;
+        const url = `${this.url}/legalholds`;
         return this.doGet(url);
     };
 
     createLegalHold = (data: CreateLegalHold) => {
-        const url = `${this.url}/legalhold`;
+        const url = `${this.url}/legalholds`;
         return this.doWithBody(url, 'post', data);
     };
 
     releaseLegalHold = (id: string) => {
-        const url = `${this.url}/legalhold/${id}/release`;
+        const url = `${this.url}/legalholds/${id}/release`;
         return this.doWithBody(url, 'post', {});
     };
 
     updateLegalHold = (id: string, data: UpdateLegalHold) => {
-        const url = `${this.url}/legalhold/${id}`;
+        const url = `${this.url}/legalholds/${id}`;
         return this.doWithBody(url, 'put', data);
     };
 

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -13,12 +13,12 @@ class APIClient {
     };
 
     getLegalHolds = () => {
-        const url = `${this.url}/legalhold/list`;
+        const url = `${this.url}/legalhold`;
         return this.doGet(url);
     };
 
     createLegalHold = (data: CreateLegalHold) => {
-        const url = `${this.url}/legalhold/create`;
+        const url = `${this.url}/legalhold`;
         return this.doWithBody(url, 'post', data);
     };
 
@@ -28,7 +28,7 @@ class APIClient {
     };
 
     updateLegalHold = (id: string, data: UpdateLegalHold) => {
-        const url = `${this.url}/legalhold/${id}/update`;
+        const url = `${this.url}/legalhold/${id}`;
         return this.doWithBody(url, 'put', data);
     };
 

--- a/webapp/src/client.ts
+++ b/webapp/src/client.ts
@@ -19,22 +19,22 @@ class APIClient {
 
     createLegalHold = (data: CreateLegalHold) => {
         const url = `${this.url}/legalhold/create`;
-        return this.doPost(url, data);
+        return this.doWithBody(url, 'post', data);
     };
 
     releaseLegalHold = (id: string) => {
         const url = `${this.url}/legalhold/${id}/release`;
-        return this.doPost(url, {});
+        return this.doWithBody(url, 'post', {});
     };
 
     updateLegalHold = (id: string, data: UpdateLegalHold) => {
         const url = `${this.url}/legalhold/${id}/update`;
-        return this.doPost(url, data);
+        return this.doWithBody(url, 'put', data);
     };
 
     testAmazonS3Connection = () => {
         const url = `${this.url}/test_amazon_s3_connection`;
-        return this.doPost(url, {}) as Promise<{message: string}>;
+        return this.doWithBody(url, 'post', {}) as Promise<{message: string}>;
     };
 
     private doGet = async (url: string, headers = {}) => {
@@ -58,9 +58,9 @@ class APIClient {
         });
     };
 
-    private doPost = async (url: string, body: any, headers = {}) => {
+    private doWithBody = async (url: string, method: string, body: any, headers = {}) => {
         const options = {
-            method: 'post',
+            method,
             body: JSON.stringify(body),
             headers,
         };


### PR DESCRIPTION
#### Summary
- Changes the API path to `/api/v1/legalholds` (from `/api/v1/legalhold`)
- Changes the `.../update` endpoint to use `PUT` instead of `POST`, removing the `/update` in the path.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-59829