### PR TITLE
fix: check for valid date in frontend

### DIFF
--- a/webapp/src/components/create_legal_hold_form.tsx
+++ b/webapp/src/components/create_legal_hold_form.tsx
@@ -8,6 +8,7 @@ import {GenericModal} from '@/components/mattermost-webapp/generic_modal/generic
 import Input from '@/components/mattermost-webapp/input/input';
 
 import './create_legal_hold_form.scss';
+import { InputProps } from 'react-select';
 
 interface CreateLegalHoldFormProps {
     createLegalHold: (data: CreateLegalHold) => Promise<any>;
@@ -29,10 +30,20 @@ const CreateLegalHoldForm = (props: CreateLegalHoldFormProps) => {
     };
 
     const startsAtChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
+        // Check if date is valid
+        const inputValue = new Date(e.target.value);
+        if (Number.isNaN(inputValue.getTime())) {
+            e.target.value = '';
+        }
         setStartsAt(e.target.value);
     };
 
     const endsAtChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
+        // Check if date is valid
+        const inputValue = new Date(e.target.value);
+        if (Number.isNaN(inputValue.getTime())) {
+            e.target.value = '';
+        }
         setEndsAt(e.target.value);
     };
 

--- a/webapp/src/components/update_legal_hold_form/update_legal_hold_form.tsx
+++ b/webapp/src/components/update_legal_hold_form/update_legal_hold_form.tsx
@@ -33,6 +33,11 @@ const UpdateLegalHoldForm = (props: UpdateLegalHoldFormProps) => {
     };
 
     const endsAtChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
+        // Check if date is valid
+        const inputValue = new Date(e.target.value);
+        if (Number.isNaN(inputValue.getTime())) {
+            e.target.value = '';
+        }
         setEndsAt(e.target.value);
     };
 
@@ -231,4 +236,3 @@ const UpdateLegalHoldForm = (props: UpdateLegalHoldFormProps) => {
 };
 
 export default UpdateLegalHoldForm;
-


### PR DESCRIPTION
#### Summary

Changes the `onChange` function for date files and resets the field in the date set up is invalid.

Tried adding a `HTMLInput.setCustomValidity` method but our form does now follow that flow it seems, hence opted for not allowing the user to have an invalid input set in the field (which should not happen very frequently).

Fixes #111
