### PR TITLE
fix: show underlying errors in the update form and make exclude public channels the default

### DIFF
--- a/server/api.go
+++ b/server/api.go
@@ -199,7 +199,7 @@ func (p *Plugin) updateLegalHold(w http.ResponseWriter, r *http.Request) {
 	mmConfigComplianceEnabled := config.ComplianceSettings.Enable != nil && *config.ComplianceSettings.Enable
 
 	if err = updateLegalHold.IsValid(mmConfigComplianceEnabled); err != nil {
-		http.Error(w, "LegalHold update data is not valid", http.StatusBadRequest)
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		p.Client.Log.Error(err.Error())
 		return
 	}

--- a/webapp/src/components/create_legal_hold_form.tsx
+++ b/webapp/src/components/create_legal_hold_form.tsx
@@ -21,7 +21,7 @@ const CreateLegalHoldForm = (props: CreateLegalHoldFormProps) => {
     const [startsAt, setStartsAt] = useState('');
     const [endsAt, setEndsAt] = useState('');
     const [saving, setSaving] = useState(false);
-    const [excludePublicChannels, setExcludePublicChannels] = useState(false);
+    const [excludePublicChannels, setExcludePublicChannels] = useState(true);
     const [serverError, setServerError] = useState('');
 
     const displayNameChanged = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/webapp/src/components/update_legal_hold_form/update_legal_hold_form.tsx
+++ b/webapp/src/components/update_legal_hold_form/update_legal_hold_form.tsx
@@ -25,7 +25,7 @@ const UpdateLegalHoldForm = (props: UpdateLegalHoldFormProps) => {
     const [startsAt, setStartsAt] = useState('');
     const [endsAt, setEndsAt] = useState('');
     const [saving, setSaving] = useState(false);
-    const [excludePublicChannels, setExcludePublicChannels] = useState(false);
+    const [excludePublicChannels, setExcludePublicChannels] = useState(true);
     const [serverError, setServerError] = useState('');
 
     const displayNameChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -231,4 +231,3 @@ const UpdateLegalHoldForm = (props: UpdateLegalHoldFormProps) => {
 };
 
 export default UpdateLegalHoldForm;
-


### PR DESCRIPTION
#### Summary
- Show validation errors to the user in the update form
- Make exclude public channels true by default

Closes #114
