### PR TITLE
Bump version to 1.0.1

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,9 +4,9 @@
   "description": "This plugin adds Legal Hold functionality to Mattermost.",
   "homepage_url": "https://github.com/mattermost/mattermost-plugin-legal-hold",
   "support_url": "https://github.com/mattermost/mattermost-plugin-legal-hold/issues",
-  "release_notes_url": "https://github.com/mattermost/mattermost-plugin-legal-hold/releases/tag/v0.4.3",
+  "release_notes_url": "https://github.com/mattermost/mattermost-plugin-legal-hold/releases/tag/v1.0.1",
   "icon_path": "assets/starter-template-icon.svg",
-  "version": "0.5.0-rc.1",
+  "version": "1.0.1",
   "min_server_version": "6.2.1",
   "server": {
     "executables": {


### PR DESCRIPTION
#### Summary
Bump version number to 1.0.1 since the `make major` did not do it automatically for 1.0

#### Ticket Link
NONE