### PR TITLE
Surface deactivated users in the search input & E2E fixes

### DIFF
--- a/e2e/playwright/README.md
+++ b/e2e/playwright/README.md
@@ -7,7 +7,7 @@ What this script does:
 -   `cd mattermost`
 -   Install webapp dependencies - `cd webapp && npm i`
 -   Install Playwright test dependencies - `cd ../e2e-tests/playwright && npm i`
--   Install Playwright - `npx install playwright`
+-   Install Playwright - `npx playwright install`
 -   Install Legal Hold plugin e2e dependencies - `cd ../../../mattermost-plugin-legal-hold/e2e/playwright && npm i`
 -   Build and deploy plugin with e2e support - `make deploy`
 

--- a/e2e/playwright/tests/create_legal_hold.spec.ts
+++ b/e2e/playwright/tests/create_legal_hold.spec.ts
@@ -21,13 +21,12 @@ test('Admin user can create a legal hold successfully', async ({pw, pages}) => {
 
     // Create legal hold
     const legalHoldName = `New Hold ${getRandomId()}`;
-    const today = new Date().toISOString().split('T')[0];
+    const today = new Date().toLocaleDateString();
     await createLegalHold(pluginPage, legalHoldName, [user.username], today);
 
     // Verify legal hold is created and details are correct
     await expect(pluginPage.getLegalHold(legalHoldName)).toBeVisible();
-    const [year, month, day] = today.split('-');
-    expect(await pluginPage.getStartDate(legalHoldName)).toHaveText(`${month}/${day}/${year}`);
+    expect(await pluginPage.getStartDate(legalHoldName)).toHaveText(today);
     expect(await pluginPage.getEndDate(legalHoldName)).toHaveText('Never');
     expect(await pluginPage.getUsers(legalHoldName)).toHaveText('1 users');
 });

--- a/e2e/playwright/tests/create_legal_hold.spec.ts
+++ b/e2e/playwright/tests/create_legal_hold.spec.ts
@@ -22,7 +22,7 @@ test('Admin user can create a legal hold successfully', async ({pw, pages}) => {
     // Create legal hold
     const legalHoldName = `New Hold ${getRandomId()}`;
     const today = new Date();
-    const isoString = today.toISOString().split('T')[0]
+    const isoString = today.toISOString().split('T')[0];
     await createLegalHold(pluginPage, legalHoldName, [user.username], isoString);
 
     // Verify legal hold is created and details are correct

--- a/e2e/playwright/tests/create_legal_hold.spec.ts
+++ b/e2e/playwright/tests/create_legal_hold.spec.ts
@@ -21,12 +21,14 @@ test('Admin user can create a legal hold successfully', async ({pw, pages}) => {
 
     // Create legal hold
     const legalHoldName = `New Hold ${getRandomId()}`;
-    const today = new Date().toLocaleDateString();
-    await createLegalHold(pluginPage, legalHoldName, [user.username], today);
+    const today = new Date();
+    const isoString = today.toISOString().split('T')[0]
+    await createLegalHold(pluginPage, legalHoldName, [user.username], isoString);
 
     // Verify legal hold is created and details are correct
     await expect(pluginPage.getLegalHold(legalHoldName)).toBeVisible();
-    expect(await pluginPage.getStartDate(legalHoldName)).toHaveText(today);
+    const dateString = today.toLocaleDateString('en-US');
+    expect(await pluginPage.getStartDate(legalHoldName)).toHaveText(dateString);
     expect(await pluginPage.getEndDate(legalHoldName)).toHaveText('Never');
     expect(await pluginPage.getUsers(legalHoldName)).toHaveText('1 users');
 });

--- a/webapp/src/components/users_input/users_input.jsx
+++ b/webapp/src/components/users_input/users_input.jsx
@@ -54,7 +54,7 @@ export default class UsersInput extends React.Component {
     };
 
     debouncedSearchProfiles = debounce((term, callback) => {
-        this.props.actions.searchProfiles(term).then(({data}) => {
+        this.props.actions.searchProfiles(term, {allow_inactive: true}).then(({data}) => {
             callback(data);
         }).catch(() => {
             // eslint-disable-next-line no-console


### PR DESCRIPTION
#### Summary
Deactivated users were not appearing in the search results. I tested the functionality to see if the actual job works with deactivated users and from what I can tell it's fine. I don't have intimate knowledge of how the plugin works though.

Also fixed the failing e2e tests.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62099

