### PR TITLE
feat: allow setting an environment variable to identify warm nodes

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -32,6 +32,13 @@
         "default": "1:00am -0700"
       },
       {
+        "key": "WarmNodeEnvironmentVariable",
+        "display_name": "Warm Node Environment Variable:",
+        "type": "text",
+        "default": "",
+        "help_text": "The name of the environment variable that will be set to check to determine if a node running the plugin is warm or not. Setting the variable to any value will be considered warm."
+      },
+      {
         "key": "LegalHoldsSettings",
         "display_name": "Legal Holds:",
         "type": "custom"

--- a/server/config/configuration.go
+++ b/server/config/configuration.go
@@ -14,8 +14,9 @@ import "github.com/mattermost/mattermost-server/v6/model"
 // If you add non-reference types to your Configuration struct, be sure to rewrite Clone as a deep
 // copy appropriate for your types.
 type Configuration struct {
-	TimeOfDay              string
-	AmazonS3BucketSettings AmazonS3BucketSettings
+	TimeOfDay                   string
+	WarmNodeEnvironmentVariable string
+	AmazonS3BucketSettings      AmazonS3BucketSettings
 }
 
 type AmazonS3BucketSettings struct {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -174,21 +174,26 @@ func (p *Plugin) Reconfigure() error {
 		return errors.New("unable to initialize the files storage")
 	}
 
-	if err = filesBackend.TestConnection(); err != nil {
-		pluginConfig := p.Client.Configuration.GetPluginConfig()
+	// Avoid running the filebackend check on warm nodes
+	if !IsWarmNode(p.configuration) {
+		if err = filesBackend.TestConnection(); err != nil {
+			pluginConfig := p.Client.Configuration.GetPluginConfig()
 
-		// Disable the S3 settings in case the AWS config is invalid
-		pluginConfig["amazons3bucketsettings"].(map[string]interface{})["Enable"] = false
+			// Disable the S3 settings in case the AWS config is invalid
+			pluginConfig["amazons3bucketsettings"].(map[string]interface{})["Enable"] = false
 
-		confErr := p.Client.Configuration.SavePluginConfig(pluginConfig)
-		if confErr != nil {
-			p.Client.Log.Error("Error while saving plugin config.", "Error", confErr.Error())
-			return confErr
+			confErr := p.Client.Configuration.SavePluginConfig(pluginConfig)
+			if confErr != nil {
+				p.Client.Log.Error("Error while saving plugin config.", "Error", confErr.Error())
+				return confErr
+			}
+
+			err = errors.Wrap(err, "connection test for filestore failed")
+			p.Client.Log.Error(err.Error())
+			return err
 		}
-
-		err = errors.Wrap(err, "connection test for filestore failed")
-		p.Client.Log.Error(err.Error())
-		return err
+	} else {
+		p.Client.Log.Debug("Skipping filestore connection test on warm node")
 	}
 
 	p.FileBackend = filesBackend

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"sync"
 
@@ -251,4 +252,17 @@ func FixedFileSettingsToFileBackendSettings(fileSettings model.FileSettings) fil
 		AmazonS3RequestTimeoutMilliseconds: *fileSettings.AmazonS3RequestTimeoutMilliseconds,
 		SkipVerify:                         false,
 	}
+}
+
+// IsWarmNode returns true if the plugin is running on a warm node, false otherwise.
+// In order to determine if the node is warm, the plugin configuration contains a setting that
+// indicates an environment variable name that this function checks for.
+// If the environment variable is set **with any value** the node is considered warm.
+func IsWarmNode(c *config.Configuration) bool {
+	if c.WarmNodeEnvironmentVariable != "" {
+		_, present := os.LookupEnv(c.WarmNodeEnvironmentVariable)
+		return present
+	}
+
+	return false
 }


### PR DESCRIPTION
#### Summary
- Add configuration option "Warm node environment variable"
- Setting that configuration option to an environment variable name will make the plugin initialization (`Reconfigure()`) check for that variable existence.
- If that variable exist in the running node, the filebackend connection test is skipped and a debug log is printed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-62965
