### PR TITLE
fix: upgrade postgresql for playwright tests

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     services:
       postgres:
-        image: mattermostdevelopment/mirrored-postgres:12
+        image: mattermostdevelopment/mirrored-postgres:13
         env:
           POSTGRES_USER: mmuser
           POSTGRES_PASSWORD: mostest

--- a/e2e/playwright/tests/create_legal_hold.spec.ts
+++ b/e2e/playwright/tests/create_legal_hold.spec.ts
@@ -1,10 +1,11 @@
 import {test, expect} from '@e2e-support/test_fixture';
 import {getRandomId} from '@e2e-support/util';
+import pages from '@e2e-support/ui/pages';
 
 import LegalHoldPluginPage from '../pages/legal_hold_plugin';
 import {createLegalHold} from '../support/legal_hold';
 
-test('Admin user can create a legal hold successfully', async ({pw, pages}) => {
+test('Admin user can create a legal hold successfully', async ({pw}) => {
     // Do setup and log in as admin user
     const {adminUser, adminClient, user} = await pw.initSetup();
     const {page} = await pw.testBrowser.login(adminUser);

--- a/e2e/playwright/tests/release_legal_hold.spec.ts
+++ b/e2e/playwright/tests/release_legal_hold.spec.ts
@@ -1,5 +1,6 @@
 import {test, expect} from '@e2e-support/test_fixture';
 import {getRandomId} from '@e2e-support/util';
+import pages from '@e2e-support/ui/pages';
 
 import PluginPage from '../pages/legal_hold_plugin';
 import {createLegalHold} from '../support/legal_hold';
@@ -7,7 +8,7 @@ import {createLegalHold} from '../support/legal_hold';
 let pluginPage: PluginPage;
 const legalHoldName = `New Hold ${getRandomId()}`;
 
-test.beforeEach(async ({pw, pages}) => {
+test.beforeEach(async ({pw}) => {
     // Do setup and log in as admin user
     const {adminUser, adminClient, user} = await pw.initSetup();
     const {page} = await pw.testBrowser.login(adminUser);


### PR DESCRIPTION
#### Summary

Playwright tests [were failing](https://github.com/mattermost/mattermost-plugin-legal-hold/actions/runs/13282340411/job/37083224510?pr=134) because the minimum postgresql version is 13 and we had 12 and updated tests to follow changes in the e2e support library.
