### PR TITLE
test(e2e): send company_country when requesting trial license

### DIFF
--- a/e2e/playwright/tests/test.setup.ts
+++ b/e2e/playwright/tests/test.setup.ts
@@ -58,7 +58,7 @@ async function requestTrialLicense(adminClient: Client) {
             receive_emails_accepted: true,
             terms_accepted: true,
             users: 100,
-            company_country: 'e2e-ci-test',
+            company_country: 'US',
         });
     } catch (e) {
         console.error('Failed to request trial license', e);

--- a/e2e/playwright/tests/test.setup.ts
+++ b/e2e/playwright/tests/test.setup.ts
@@ -58,6 +58,7 @@ async function requestTrialLicense(adminClient: Client) {
             receive_emails_accepted: true,
             terms_accepted: true,
             users: 100,
+            company_country: 'e2e-ci-test',
         });
     } catch (e) {
         console.error('Failed to request trial license', e);


### PR DESCRIPTION
#### Summary

This fixes a change in the trial request which now requires the country parameter to be set.

