### PR TITLE
[CLD-9496 ] Disallow enterprise licenses on the Entry SKU

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -19,7 +19,8 @@ import (
 )
 
 const (
-	LegalHoldJobID = "legal_hold_job"
+	LegalHoldJobID              = "legal_hold_job"
+	MattermostEntrySkuShortName = "entry"
 )
 
 // Plugin implements the interface expected by the Mattermost server to communicate between the server and plugin processes.
@@ -60,7 +61,7 @@ func (p *Plugin) OnActivate() error {
 	config := p.API.GetConfig()
 	license := p.API.GetLicense()
 
-	if !pluginapi.IsEnterpriseLicensedOrDevelopment(config, license) {
+	if !pluginapi.IsEnterpriseLicensedOrDevelopment(config, license) || (!pluginapi.IsConfiguredForDevelopment(config) && license.SkuShortName == MattermostEntrySkuShortName) {
 		return fmt.Errorf("this plugin requires an Enterprise license")
 	}
 


### PR DESCRIPTION
#### Summary
[The new Entry SKU](https://github.com/mattermost/mattermost/pull/33672) will not allow the usage of the Legal Hold plugin. This PR adjusts the check so that its supported in 2 cases:
1. Development mode is enabled
OR 
2. A professional/enterprise/enterprise advanced license is loaded. 

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-9496
