### PR TITLE
Bump plugin version to 1.1.5

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
   "support_url": "https://github.com/mattermost/mattermost-plugin-legal-hold/issues",
   "release_notes_url": "https://github.com/mattermost/mattermost-plugin-legal-hold/releases/tag/v1.0.1",
   "icon_path": "assets/starter-template-icon.svg",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "min_server_version": "6.2.1",
   "server": {
     "executables": {


### PR DESCRIPTION
#### Summary
Bumping plugin to version 1.1.5 in preparation for a new release.

#### Ticket Link
NONE