### PR TITLE
MM-68439 Normalize file names in legal hold export paths

### DIFF
--- a/server/legalhold/legal_hold.go
+++ b/server/legalhold/legal_hold.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -290,14 +291,23 @@ func (ex *Execution) ExportFiles(channelID string, batchCreateAt int64, batchPos
 
 	// Copy the files from one to another.
 	for _, fileInfo := range fileInfos {
-		path := ex.filePath(
+		destPath, err := ex.filePath(
 			channelID,
 			batchCreateAt,
 			batchPostID,
 			fileInfo.ID,
 			fileInfo.Name,
 		)
-		err = ex.fileBackend.CopyFile(fileInfo.Path, path)
+		if err != nil {
+			ex.papi.LogWarn(
+				"Skipping file with unsafe name in legal hold export",
+				"file_id", fileInfo.ID,
+				"error", err.Error(),
+			)
+			continue
+		}
+
+		err = ex.fileBackend.CopyFile(fileInfo.Path, destPath)
 		if err != nil {
 			ex.papi.LogError(fmt.Sprintf("Failed to find file attachment to copy %s", fileInfo.Path))
 			// Continue anyway so the job doesn't get completely stuck.
@@ -314,7 +324,7 @@ func (ex *Execution) ExportFiles(channelID string, batchCreateAt int64, batchPos
 			return err
 		}
 
-		err = ex.WriteFileHash(path, h)
+		err = ex.WriteFileHash(destPath, h)
 		if err != nil {
 			return err
 		}
@@ -498,16 +508,31 @@ func (ex *Execution) indexPath() string {
 }
 
 // filePath returns the file path for a given file attachment within
-// this Execution.
-func (ex *Execution) filePath(channelID string, batchCreateAt int64, batchPostID string, fileID string, fileName string) string {
-	return fmt.Sprintf(
+// this Execution. The fileName is reduced to its base component before being
+// used in path construction, and the resulting path is verified to stay within
+// the Execution's base path so that a hostile FileInfo cannot cause writes
+// outside the legal hold directory.
+func (ex *Execution) filePath(channelID string, batchCreateAt int64, batchPostID string, fileID string, fileName string) (string, error) {
+	cleanName := filepath.Base(fileName)
+	if cleanName == "" || cleanName == "." || cleanName == ".." || cleanName == string(filepath.Separator) {
+		return "", fmt.Errorf("invalid file name %q", fileName)
+	}
+
+	p := fmt.Sprintf(
 		"%s/files/files-%d-%s/%s/%s",
 		ex.channelPath(channelID),
 		batchCreateAt,
 		batchPostID,
 		fileID,
-		fileName,
+		cleanName,
 	)
+
+	base := ex.basePath()
+	if cleaned := filepath.ToSlash(filepath.Clean(p)); cleaned != p || !strings.HasPrefix(cleaned, base+"/") {
+		return "", fmt.Errorf("constructed legal hold file path %q escapes base %q", p, base)
+	}
+
+	return p, nil
 }
 
 // hashFromReader returns the HMAC-SHA512 hash of the reader's contents.

--- a/server/legalhold/legal_hold.go
+++ b/server/legalhold/legal_hold.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -251,7 +252,7 @@ func (ex *Execution) ExportData() error {
 // WritePostsBatchToFile writes a batch of posts from a channel to the appropriate file
 // in the file backend.
 func (ex *Execution) WritePostsBatchToFile(channelID string, posts []model.LegalHoldPost) error {
-	path := ex.messagesBatchPath(channelID, posts[0].PostCreateAt, posts[0].PostID)
+	msgKey := ex.messagesBatchPath(channelID, posts[0].PostCreateAt, posts[0].PostID)
 
 	csvContent, err := gocsv.MarshalString(&posts)
 	if err != nil {
@@ -260,7 +261,7 @@ func (ex *Execution) WritePostsBatchToFile(channelID string, posts []model.Legal
 
 	csvReader := strings.NewReader(csvContent)
 
-	_, err = ex.fileBackend.WriteFile(csvReader, path)
+	_, err = ex.fileBackend.WriteFile(csvReader, msgKey)
 	if err != nil {
 		return err
 	}
@@ -272,7 +273,7 @@ func (ex *Execution) WritePostsBatchToFile(channelID string, posts []model.Legal
 		return err
 	}
 
-	err = ex.WriteFileHash(path, h)
+	err = ex.WriteFileHash(msgKey, h)
 
 	return err
 }
@@ -428,8 +429,8 @@ func (ex *Execution) UpdateIndexes(now int64) error {
 	return err
 }
 
-func (ex *Execution) WriteFileHash(path, hash string) error {
-	ex.hashes[path] = hash
+func (ex *Execution) WriteFileHash(key, hash string) error {
+	ex.hashes[key] = hash
 	return nil
 }
 
@@ -514,15 +515,14 @@ func (ex *Execution) indexPath() string {
 // outside the legal hold directory.
 func (ex *Execution) filePath(channelID string, batchCreateAt int64, batchPostID string, fileID string, fileName string) (string, error) {
 	cleanName := filepath.Base(fileName)
-	if cleanName == "" || cleanName == "." || cleanName == ".." || cleanName == string(filepath.Separator) {
+	if cleanName == "" || cleanName == "." || cleanName == ".." || cleanName == "/" {
 		return "", fmt.Errorf("invalid file name %q", fileName)
 	}
 
-	p := fmt.Sprintf(
-		"%s/files/files-%d-%s/%s/%s",
+	p := path.Join(
 		ex.channelPath(channelID),
-		batchCreateAt,
-		batchPostID,
+		"files",
+		fmt.Sprintf("files-%d-%s", batchCreateAt, batchPostID),
 		fileID,
 		cleanName,
 	)

--- a/server/legalhold/legal_hold_test.go
+++ b/server/legalhold/legal_hold_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	dbsql "database/sql"
+	"strings"
 	"testing"
 	"time"
 
@@ -117,6 +118,105 @@ func TestApp_LegalHoldExecution_Execute(t *testing.T) {
 	// require.NoError(t, err)
 
 	// TODO: Do some proper assertions here to really test the functionality.
+}
+
+func TestExecution_FilePath(t *testing.T) {
+	ex := &Execution{
+		LegalHold: &model.LegalHold{
+			ID:   "abc123",
+			Name: "holdname",
+		},
+	}
+	const (
+		channelID     = "channelid1"
+		batchCreateAt = int64(1700000000000)
+		batchPostID   = "postid1"
+		fileID        = "fileid1"
+	)
+	basePath := ex.LegalHold.BasePath()
+	expectedPrefix := basePath + "/"
+
+	testCases := []struct {
+		name      string
+		fileName  string
+		expectErr bool
+		expected  string
+	}{
+		{
+			name:     "normal filename",
+			fileName: "document.pdf",
+			expected: basePath + "/channelid1/files/files-1700000000000-postid1/fileid1/document.pdf",
+		},
+		{
+			name:     "filename with spaces",
+			fileName: "my document.pdf",
+			expected: basePath + "/channelid1/files/files-1700000000000-postid1/fileid1/my document.pdf",
+		},
+		{
+			name:      "path traversal with forward slashes",
+			fileName:  "../../../../plugins/com.mattermost.plugin-legal-hold.tar.gz",
+			expectErr: false,
+			expected:  basePath + "/channelid1/files/files-1700000000000-postid1/fileid1/com.mattermost.plugin-legal-hold.tar.gz",
+		},
+		{
+			name:      "absolute path",
+			fileName:  "/etc/passwd",
+			expectErr: false,
+			expected:  basePath + "/channelid1/files/files-1700000000000-postid1/fileid1/passwd",
+		},
+		{
+			name:      "single dot-dot",
+			fileName:  "..",
+			expectErr: true,
+		},
+		{
+			name:      "single dot",
+			fileName:  ".",
+			expectErr: true,
+		},
+		{
+			name:      "empty name",
+			fileName:  "",
+			expectErr: true,
+		},
+		{
+			name:      "just a slash",
+			fileName:  "/",
+			expectErr: true,
+		},
+		{
+			name:      "trailing slash gets cleaned",
+			fileName:  "foo/",
+			expectErr: false,
+			expected:  basePath + "/channelid1/files/files-1700000000000-postid1/fileid1/foo",
+		},
+		{
+			name:      "filename with embedded traversal via backslashes (linux-safe)",
+			fileName:  "..\\..\\plugins\\evil.tar.gz",
+			expectErr: false,
+			// On Linux, backslashes are valid filename characters; Base returns the whole string.
+			expected: basePath + "/channelid1/files/files-1700000000000-postid1/fileid1/..\\..\\plugins\\evil.tar.gz",
+		},
+		{
+			name:      "ends with dot-dot segment",
+			fileName:  "foo/..",
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ex.filePath(channelID, batchCreateAt, batchPostID, fileID, tc.fileName)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, got)
+			require.True(t, strings.HasPrefix(got, expectedPrefix),
+				"path %q must stay inside base %q", got, basePath)
+		})
+	}
 }
 
 func TestLegalHold_Hash(t *testing.T) {


### PR DESCRIPTION
#### Summary
This PR ensure the FileInfo.Name is reduced to its base component via filepath.Base before using it in export destination paths, and verify the resulting path stays under the legal hold base directory. Skips (with a warning log) any FileInfo whose name doesn't normalize to a valid path component, so a single malformed entry doesn't abort the run.

Includes table-driven tests for the filePath helper.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68439
