### PR TITLE
bump: 1.1.6

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -6,7 +6,7 @@
   "support_url": "https://github.com/mattermost/mattermost-plugin-legal-hold/issues",
   "release_notes_url": "https://github.com/mattermost/mattermost-plugin-legal-hold/releases/tag/v1.0.1",
   "icon_path": "assets/starter-template-icon.svg",
-  "version": "1.1.4",
+  "version": "1.1.6",
   "min_server_version": "6.2.1",
   "server": {
     "executables": {

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
   "description": "This plugin adds Legal Hold functionality to Mattermost.",
   "homepage_url": "https://github.com/mattermost/mattermost-plugin-legal-hold",
   "support_url": "https://github.com/mattermost/mattermost-plugin-legal-hold/issues",
-  "release_notes_url": "https://github.com/mattermost/mattermost-plugin-legal-hold/releases/tag/v1.0.1",
+  "release_notes_url": "https://github.com/mattermost/mattermost-plugin-legal-hold/releases/tag/v1.1.6",
   "icon_path": "assets/starter-template-icon.svg",
   "version": "1.1.6",
   "min_server_version": "6.2.1",


### PR DESCRIPTION
## Summary
- Bump plugin version to 1.1.6

This PR still has the old way of making releases (I have to manually bump the `plugin.json` file before tagging. Requesting reviewers from my TZ to speed up the process.